### PR TITLE
Related Products and Outfits

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,17 +1,22 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": "airbnb",
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "rules": {
-        "import/extensions": ["error", "ignorePackages", {
-            "js": "never",
-            "jsx": "never"
-        }]
-    }
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["airbnb", "prettier"],
+  "plugins": ["prettier"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        "js": "never",
+        "jsx": "never"
+      }
+    ]
+  }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "overrides": [
+    {
+      "files": ["**/*.css", "**/*.scss", "**/*.html"],
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.12.0",
+        "react-multi-carousel": "^2.8.4",
         "styled-components": "^5.3.6"
       },
       "devDependencies": {
@@ -30,7 +32,8 @@
         "@babel/preset-env": "^7.20.2",
         "@babel/preset-react": "^7.18.6",
         "@jest/globals": "^29.7.0",
-        "@testing-library/react": "^14.0.0",
+        "@testing-library/react": "^14.1.2",
+        "@testing-library/user-event": "^14.5.1",
         "babel-jest": "^29.5.0",
         "babel-loader": "^8.2.5",
         "babel-preset-react": "^6.24.1",
@@ -42,7 +45,7 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "html-webpack-plugin": "^5.5.0",
-        "jest": "^29.5.0",
+        "jest": "^29.7.0",
         "react-test-renderer": "^18.2.0",
         "style-loader": "^3.3.1",
         "webpack": "^5.74.0",
@@ -2785,9 +2788,9 @@
       "dev": true
     },
     "node_modules/@testing-library/react": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.0.tgz",
-      "integrity": "sha512-hcvfZEEyO0xQoZeHmUbuMs7APJCGELpilL7bY+BaJaMP57aWc6q1etFwScnoZDheYjk4ESdlzPdQ33IbsKAK/A==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
+      "integrity": "sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -2800,6 +2803,19 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
+      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -10173,10 +10189,26 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/react-multi-carousel": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/react-multi-carousel/-/react-multi-carousel-2.8.4.tgz",
+      "integrity": "sha512-7Is5Wr+m2ebkR+oq2Su2tjUdBwpVtB2O6Tjb74KDNfxWe/FrsTQwezTJTk/r9cKCrRp9Li308v822/5bZm7XKg==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/react-shallow-renderer": {
       "version": "16.15.0",
@@ -14335,15 +14367,22 @@
       }
     },
     "@testing-library/react": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.0.tgz",
-      "integrity": "sha512-hcvfZEEyO0xQoZeHmUbuMs7APJCGELpilL7bY+BaJaMP57aWc6q1etFwScnoZDheYjk4ESdlzPdQ33IbsKAK/A==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.1.2.tgz",
+      "integrity": "sha512-z4p7DVBTPjKM5qDZ0t5ZjzkpSNb+fZy1u6bzO7kk8oeGagpPCAtgh4cx1syrfp7a+QWkM021jGqjJaxJJnXAZg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
+      "integrity": "sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -20038,10 +20077,21 @@
         "scheduler": "^0.23.0"
       }
     },
+    "react-icons": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "requires": {}
+    },
     "react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "react-multi-carousel": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/react-multi-carousel/-/react-multi-carousel-2.8.4.tgz",
+      "integrity": "sha512-7Is5Wr+m2ebkR+oq2Su2tjUdBwpVtB2O6Tjb74KDNfxWe/FrsTQwezTJTk/r9cKCrRp9Li308v822/5bZm7XKg=="
     },
     "react-shallow-renderer": {
       "version": "16.15.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "product-detail-page",
   "main": "index.js",
-
   "scripts": {
     "start": "webpack server --config webpack.config.js",
     "test": "jest"
@@ -24,7 +23,8 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
     "@jest/globals": "^29.7.0",
-    "@testing-library/react": "^14.0.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.5.1",
     "babel-jest": "^29.5.0",
     "babel-loader": "^8.2.5",
     "babel-preset-react": "^6.24.1",
@@ -36,7 +36,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "html-webpack-plugin": "^5.5.0",
-    "jest": "^29.5.0",
+    "jest": "^29.7.0",
     "react-test-renderer": "^18.2.0",
     "style-loader": "^3.3.1",
     "webpack": "^5.74.0",
@@ -57,6 +57,8 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.12.0",
+    "react-multi-carousel": "^2.8.4",
     "styled-components": "^5.3.6"
   }
 }

--- a/src/components/RelatedProducts/ComparisonTable.jsx
+++ b/src/components/RelatedProducts/ComparisonTable.jsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+
+// Utility Functions
+const combine = (obj1, obj2) => {
+  var newObj = {};
+
+  obj1.features.forEach(
+    (item) => (newObj[item.feature] = { currentProduct: item.value }),
+  );
+  obj2.features.forEach((item) => {
+    if (newObj[item.feature]) {
+      newObj[item.feature] = {
+        ...newObj[item.feature],
+        ...{ comparedProduct: item.value },
+      };
+    } else {
+      newObj[item.feature] = { comparedProduct: item.value };
+    }
+  });
+
+  return newObj;
+};
+
+const ComparisonTable = ({ currentProduct, comparedProduct }) => {
+  const productObj = combine(currentProduct, comparedProduct);
+
+  return (
+    <table className="related-table">
+      <thead>
+        <tr>
+          <th>{currentProduct.name}</th>
+          <th></th>
+          <th>{comparedProduct.name}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>${currentProduct.default_price}</td>
+          <td>Price</td>
+          <td>${comparedProduct.default_price}</td>
+        </tr>
+        <tr>
+          <td>{currentProduct.category}</td>
+          <td>Category</td>
+          <td>{comparedProduct.category}</td>
+        </tr>
+        {Object.keys(productObj).map(function (key, index) {
+          return (
+            <tr key={index}>
+              <td>{productObj[key].currentProduct}</td>
+              <td>{key}</td>
+              <td>{productObj[key].comparedProduct}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
+
+export default ComparisonTable;

--- a/src/components/RelatedProducts/Outfit.css
+++ b/src/components/RelatedProducts/Outfit.css
@@ -1,0 +1,165 @@
+.outfit-image {
+  width: 100%;
+  height: 26em;
+  object-fit: cover;
+  object-position: center center;
+  border: 1px solid #ddd;
+  background-color: #ddd;
+}
+
+.outfit-alt-text {
+  width: 100%;
+  height: 26em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+}
+
+.outfit-card {
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+  max-width: 320px;
+  margin: auto 1rem;
+  text-align: center;
+  font-family: arial;
+  border: 1px solid #ddd;
+}
+
+.row-outfit-product {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.outfit-carousel-container {
+  width: 50%;
+  margin: auto;
+  height: auto;
+}
+
+.OutfitRatingsContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-bottom: 10px;
+}
+
+.OutfitRatings {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  margin: auto;
+  text-align: center;
+}
+
+.row-outfit-product {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: auto;
+}
+
+.outfit-card h1,
+.outfit-card h3,
+.outfit-card h2,
+.outfit-card h4 {
+  margin: 0.25rem 0;
+  font-family: Georgia, sans-serif;
+}
+
+.outfit-card h4 {
+  color: #333;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.outfit-card h3 {
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  text-transform: none;
+}
+
+.outfit-card h2 {
+  font-size: 0.875rem;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  margin-bottom: 0.75rem;
+  position: relative;
+  text-transform: none;
+  transition: all 0.2s ease-in-out;
+  font-weight: 400;
+}
+
+.row-outift-title {
+  text-align: center;
+}
+
+.row-outift-title h1 {
+  font-size: 1.5rem;
+  font-weight: 400;
+  margin-bottom: 1.5rem;
+  padding: 0 0.75rem;
+  display: inline-block;
+}
+
+.remove-button {
+  position: absolute;
+  top: 15px;
+  right: 25px;
+  cursor: pointer;
+  transition: color 0.3s;
+}
+
+.remove-button:hover .remove-icon {
+  color: black;
+}
+
+.remove-icon {
+  color: white;
+  font-size: 20px;
+  padding: 5px;
+}
+
+.add-button span {
+  font-size: 0.875rem;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  margin-bottom: 0.75rem;
+  position: relative;
+  text-transform: none;
+  transition: all 0.2s ease-in-out;
+  font-weight: 400;
+}
+
+.add-button {
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+  max-width: 320px;
+  margin: auto 1rem;
+  text-align: center;
+  font-family: arial;
+  border: 1px solid #ddd;
+}
+
+.add-icon {
+  width: 100%;
+  height: 26em;
+  object-fit: cover;
+  object-position: center center;
+  border: 1px solid #ddd;
+  background-color: #ddd;
+}
+
+.outfit-button-carousel {
+  display: flex;
+  width: 100%;
+}
+
+.outfit-carousel-item {
+  display: flex;
+  width: 100%;
+}

--- a/src/components/RelatedProducts/OutfitList.jsx
+++ b/src/components/RelatedProducts/OutfitList.jsx
@@ -1,0 +1,151 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable no-param-reassign */
+/* eslint-disable */
+import React from 'react';
+import Carousel from 'react-multi-carousel';
+import 'react-multi-carousel/lib/styles.css';
+import RelatedProducts from './index.jsx';
+import ProductStarRating from '../ReviewStars/ProductStarRating.jsx';
+import { TiDelete } from 'react-icons/ti';
+import { IoAddCircleOutline } from 'react-icons/io5';
+/* eslint-enable */
+
+// eslint-disable-next-line react/prop-types
+function AddOutfitButton({ onClick }) {
+  return (
+    <div className="outfit-card" onClick={onClick}>
+      <div className="add-button">
+        <IoAddCircleOutline
+          className="add-icon"
+          style={{
+            color: 'white',
+            stroke: 'black',
+            strokeWidth: '0.5',
+          }}
+          // eslint-disable-next-line no-return-assign
+          onMouseOver={({ target }) => (
+            // eslint-disable-next-line no-sequences
+            (target.style.color = 'black'), (target.style.stroke = 'white')
+          )}
+          // eslint-disable-next-line no-return-assign
+          onMouseOut={({ target }) => (
+            // eslint-disable-next-line no-sequences
+            (target.style.color = 'white'), (target.style.stroke = 'black')
+          )}
+        />
+        <span>Add to Outfit</span>
+      </div>
+    </div>
+  );
+}
+
+function OutfitList({ outfits, onClickAddOutfits, removeItem }) {
+  //eslint-disable-line
+  const responsive2 = {
+    superLargeDesktop: {
+      breakpoint: { max: 4000, min: 3000 },
+      items: 3,
+    },
+    desktop: {
+      breakpoint: { max: 3000, min: 1024 },
+      items: 3,
+    },
+    tablet: {
+      breakpoint: { max: 1024, min: 464 },
+      items: 2,
+    },
+    mobile: {
+      breakpoint: { max: 464, min: 0 },
+      items: 1,
+    },
+  };
+
+  return (
+    <div className="outfit-button-carousel">
+      <AddOutfitButton onClick={() => onClickAddOutfits()} />
+      {outfits && (
+        <Carousel
+          className="outfit-carousel-item"
+          responsive={responsive2}
+          swipeable={false}
+          draggable={false}
+        >
+          {outfits !== null &&
+            Object.values(outfits).map((outfitsList) => (
+              <div className="outfit-card" key={outfitsList.id}>
+                {outfitsList.photos && outfitsList.photos.length > 0 ? (
+                  <img
+                    className="outfit-image"
+                    src={outfitsList.photos[0].thumbnail_url}
+                    alt=""
+                  />
+                ) : (
+                  <div className="outfit-alt-text">No photo available</div>
+                )}
+                <div
+                  className="remove-button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeItem(outfitsList.id);
+                  }}
+                >
+                  <TiDelete
+                    className="remove-icon"
+                    style={{
+                      color: 'white',
+                      stroke: 'black',
+                      strokeWidth: '0.5',
+                    }}
+                    // eslint-disable-next-line no-return-assign
+                    onMouseOver={({ target }) => (
+                      // eslint-disable-next-line no-sequences
+                      (target.style.color = 'black'),
+                      (target.style.stroke = 'white')
+                    )}
+                    // eslint-disable-next-line no-return-assign
+                    onMouseOut={({ target }) => (
+                      // eslint-disable-next-line no-sequences
+                      (target.style.color = 'white'),
+                      (target.style.stroke = 'black')
+                    )}
+                  />
+                </div>
+                <h3>{outfitsList.category}</h3>
+                <h2>{outfitsList.name}</h2>
+                <h4>
+                  {outfitsList.sale_price ? (
+                    <>
+                      <span
+                        style={{
+                          textDecoration: 'line-through',
+                          marginRight: '5px',
+                        }}
+                      >
+                        ${outfitsList.default_price}
+                      </span>
+                      <span style={{ color: 'red' }}>
+                        ${outfitsList.sale_price}
+                      </span>
+                    </>
+                  ) : (
+                    `$${outfitsList.default_price}`
+                  )}
+                </h4>
+                <div className="OutfitRatingsContainer">
+                  <ProductStarRating
+                    productId={outfitsList.id}
+                    className="OutfitRatings"
+                  />
+                </div>
+              </div>
+            ))}
+        </Carousel>
+      )}
+    </div>
+  );
+}
+
+export default OutfitList;

--- a/src/components/RelatedProducts/RelatedProducts.css
+++ b/src/components/RelatedProducts/RelatedProducts.css
@@ -1,0 +1,126 @@
+.product-image {
+  width: 100%;
+  height: 26em;
+  object-fit: cover;
+  object-position: center center;
+  border: 1px solid #ddd;
+  background-color: #ddd;
+}
+
+.alt-text {
+  width: 100%;
+  height: 26em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+}
+
+.card {
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+  max-width: 320px;
+  margin: auto 1rem;
+  text-align: center;
+  font-family: arial;
+  border: 1px solid #ddd;
+}
+
+.row-related-product {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.carousel-container {
+  width: 50%;
+  margin: auto;
+  height: auto;
+}
+
+.RelatedProductsRatingsContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-bottom: 10px;
+}
+
+.RelatedProductsRatings {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: 100%;
+  margin: auto;
+  text-align: center;
+}
+
+.row-related-product {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: auto;
+}
+
+.card h1,
+.card h3,
+.card h2,
+.card h4 {
+  margin: 0.25rem 0;
+  font-family: Georgia, sans-serif;
+}
+
+.card h4 {
+  color: #333;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.card h3 {
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  text-transform: none;
+}
+
+.card h2 {
+  font-size: 0.875rem;
+  letter-spacing: 0.03em;
+  line-height: 1;
+  margin-bottom: 0.75rem;
+  position: relative;
+  text-transform: none;
+  transition: all 0.2s ease-in-out;
+  font-weight: 400;
+}
+
+.row-related-title {
+  text-align: center;
+}
+
+.row-related-title h1 {
+  font-size: 1.5rem;
+  font-weight: 400;
+  margin-bottom: 1.5rem;
+  padding: 0 0.75rem;
+  display: inline-block;
+}
+
+.favorite-button {
+  position: absolute;
+  top: 15px;
+  right: 25px;
+  cursor: pointer;
+  transition: color 0.3s;
+}
+
+.favorite-button:hover .star-icon {
+  color: gold;
+}
+
+.star-icon {
+  color: white;
+  font-size: 20px;
+  padding: 5px;
+}

--- a/src/components/RelatedProducts/RelatedProductsList.jsx
+++ b/src/components/RelatedProducts/RelatedProductsList.jsx
@@ -1,0 +1,114 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable no-param-reassign */
+import React from 'react';
+import Carousel from 'react-multi-carousel'; //eslint-disable-line
+import 'react-multi-carousel/lib/styles.css'; //eslint-disable-line
+import RelatedProducts from './index.jsx'; //eslint-disable-line
+import ProductStarRating from '../ReviewStars/ProductStarRating.jsx'; //eslint-disable-line
+import { BsStarFill } from 'react-icons/bs'; //eslint-disable-line
+
+function RelatedProductsList({
+  relatedItems,
+  onClickRelatedProduct,
+  setProductId,
+}) {
+  //eslint-disable-line
+  const responsive = {
+    superLargeDesktop: {
+      breakpoint: { max: 4000, min: 3000 },
+      items: 4,
+    },
+    desktop: {
+      breakpoint: { max: 3000, min: 1024 },
+      items: 4,
+    },
+    tablet: {
+      breakpoint: { max: 1024, min: 464 },
+      items: 2,
+    },
+    mobile: {
+      breakpoint: { max: 464, min: 0 },
+      items: 1,
+    },
+  };
+
+  if (!relatedItems || !relatedItems.relatedItems) {
+    //eslint-disable-line
+    // Handle the case when relatedItems or relatedItems.relatedItems is null or undefined
+    return <p>No related items available</p>;
+  }
+  const relatedItemsArray = Object.values(relatedItems.relatedItems); //eslint-disable-line
+
+  return (
+    <Carousel responsive={responsive} swipeable={false} draggable={false}>
+      {relatedItemsArray.map((relatedList) => (
+        <div
+          className="card"
+          key={relatedList.id}
+          data-key={relatedList.id}
+          onClick={onClickRelatedProduct}
+        >
+          {relatedList.photos && relatedList.photos.length > 0 ? (
+            <img
+              className="product-image"
+              src={relatedList.photos[0].thumbnail_url}
+              alt=""
+            />
+          ) : (
+            <div className="alt-text">No photo available</div>
+          )}
+          <div
+            className="favorite-button"
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+          >
+            <BsStarFill
+              className="star-icon"
+              style={{
+                color: 'white',
+                stroke: 'black',
+                strokeWidth: '0.5',
+              }}
+              // eslint-disable-next-line no-return-assign
+              onMouseOver={({ target }) => (
+                // eslint-disable-next-line no-sequences
+                (target.style.color = 'gold'), (target.style.stroke = 'white')
+              )}
+              // eslint-disable-next-line no-return-assign
+              onMouseOut={({ target }) => (
+                // eslint-disable-next-line no-sequences
+                (target.style.color = 'white'), (target.style.stroke = 'black')
+              )}
+            />
+          </div>
+          <h3>{relatedList.category}</h3>
+          <h2>{relatedList.name}</h2>
+          <h4>
+            {relatedList.sale_price ? (
+              <>
+                <span
+                  style={{ textDecoration: 'line-through', marginRight: '5px' }}
+                >
+                  ${relatedList.default_price}
+                </span>
+                <span style={{ color: 'red' }}>${relatedList.sale_price}</span>
+              </>
+            ) : (
+              `$${relatedList.default_price}`
+            )}
+          </h4>
+          <div className="RelatedProductsRatingsContainer">
+            <ProductStarRating
+              productId={relatedList.id}
+              className="RelatedProductsRatings"
+            />
+          </div>
+        </div>
+      ))}
+    </Carousel>
+  );
+}
+
+export default RelatedProductsList;

--- a/src/components/RelatedProducts/RelatedProductsList.jsx
+++ b/src/components/RelatedProducts/RelatedProductsList.jsx
@@ -12,6 +12,7 @@ function RelatedProductsList({
   relatedItems,
   onClickRelatedProduct,
   setProductId,
+  setCurrentId,
 }) {
   //eslint-disable-line
   const responsive = {
@@ -62,6 +63,7 @@ function RelatedProductsList({
             className="favorite-button"
             onClick={(e) => {
               e.stopPropagation();
+              () => setCurrentId(relatedList.id);
             }}
           >
             <BsStarFill

--- a/src/components/RelatedProducts/RelatedProducts_Test.jsx
+++ b/src/components/RelatedProducts/RelatedProducts_Test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RelatedProductsList from './RelatedProductsList';
+import '@testing-library/jest-dom';
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+
+const mockRelatedItems = {
+  relatedItems: {
+    1: {
+      id: 1,
+      category: 'Test Category',
+      name: 'Test Product',
+      default_price: '50.00',
+      sale_price: '40.00',
+      photos: [{ thumbnail_url: 'test_image_url' }],
+    },
+  },
+};
+
+const mockOnClickRelatedProduct = jest.fn();
+const mockSetProductId = jest.fn();
+
+describe('RelatedProductsList', () => {
+  it('renders related items correctly', () => {
+    render(
+      <RelatedProductsList
+        relatedItems={mockRelatedItems}
+        onClickRelatedProduct={mockOnClickRelatedProduct}
+        setProductId={mockSetProductId}
+      />,
+    );
+
+    // Ensure that the related items are rendered
+    const relatedItemElements = screen.getAllByRole('img', {
+      name: /product thumbnail/i,
+    });
+    expect(relatedItemElements.length).toBe(
+      Object.keys(mockRelatedItems.relatedItems).length,
+    );
+
+    // Simulate clicking on a related product
+    userEvent.click(relatedItemElements[0]);
+
+    // Ensure that the onClickRelatedProduct function is called with the correct arguments
+    expect(mockOnClickRelatedProduct).toHaveBeenCalledWith(expect.any(Object));
+
+    // Ensure that the setProductId function is called with the correct arguments
+    expect(mockSetProductId).toHaveBeenCalledWith(expect.any(Number));
+  });
+
+  it('handles case when relatedItems is null', () => {
+    render(<RelatedProductsList relatedItems={null} />);
+
+    // Ensure that the "No related items available" message is rendered
+    const noRelatedItemsMessage = screen.getByText(
+      /no related items available/i,
+    );
+    expect(noRelatedItemsMessage).toBeInTheDocument();
+  });
+});

--- a/src/components/RelatedProducts/index.jsx
+++ b/src/components/RelatedProducts/index.jsx
@@ -1,14 +1,182 @@
-import React from 'react';
+/* eslint-disable */
+import React, { useState, useEffect } from 'react';
+import useServerFetch from '../../hooks/useServerFetch.js';
+import RelatedProductsList from './RelatedProductsList.jsx';
+import OutfitList from './OutfitList.jsx';
+import './RelatedProducts.css';
+import './Outfit.css';
+import Modal from '../UI/Modal.jsx';
+/* eslint-enable */
 
-function RelatedProducts() {
+function RelatedProducts({ productId, setProductId, styleId }) {
+  //eslint-disable-line
+  const [relatedItems, setRelatedItems] = useState(null);
+  const [outfits, setOutfits] = useState(null);
+  const relatedFetchController = new AbortController();
+  const productIdFetchController = new AbortController();
+  const stylesFetchController = new AbortController();
+  const outfitsIdFetchController = new AbortController();
+  const outfitsStylesFetchController = new AbortController();
+
+  const getRelatedProducts = () => {
+    useServerFetch(
+      'get',
+      `products/${productId}/related`,
+      {},
+      relatedFetchController,
+    )
+      .then((res) => {
+        const items = {};
+        let counter = 0;
+        res.data.forEach((id) => {
+          useServerFetch('get', `products/${id}`, {}, productIdFetchController)
+            .then((res2) => {
+              items[res2.data.id] = res2.data;
+            })
+            .then(() => {
+              useServerFetch(
+                'get',
+                `products/${id}/styles`,
+                {},
+                stylesFetchController,
+              )
+                .then((res3) => {
+                  const styles = res3.data.results;
+                  const lowestSalePriceStyle = styles.reduce(
+                    (lowestStyle, currentStyle) => {
+                      if (
+                        !lowestStyle.sale_price ||
+                        (currentStyle.sale_price &&
+                          currentStyle.sale_price < lowestStyle.sale_price)
+                      ) {
+                        return currentStyle;
+                      }
+                      return lowestStyle;
+                    },
+                    {},
+                  );
+                  items[id].photos = lowestSalePriceStyle.photos;
+                  items[id].sale_price =
+                    lowestSalePriceStyle.sale_price || styles[0].sale_price;
+                  items[id].original_price =
+                    lowestSalePriceStyle.original_price;
+                })
+                .then(() => {
+                  counter += 1;
+                  if (Object.keys(items).length === counter) {
+                    setRelatedItems((prevState) => ({
+                      ...prevState,
+                      relatedItems: items,
+                    }));
+                  }
+                });
+            });
+        });
+      })
+      .catch((err) => {
+        console.error('Error fetching related items id', err); //eslint-disable-line
+      });
+  };
+
+  useEffect(() => {
+    getRelatedProducts();
+
+    return () => {
+      relatedFetchController.abort();
+      productIdFetchController.abort();
+      stylesFetchController.abort();
+    };
+  }, [productId]);
+
+  const onClickRelatedProduct = (e) => {
+    const currentProductId = e.currentTarget.getAttribute('data-key');
+    if (currentProductId) {
+      setProductId(currentProductId);
+    }
+  };
+
+  const onClickAddOutfits = () => {
+    const outfitsData = {};
+    useServerFetch('get', `products/${productId}`, {}, outfitsIdFetchController)
+      .then((res) => {
+        outfitsData[res.data.id] = res.data;
+      })
+      .then(() => {
+        useServerFetch(
+          'get',
+          `products/${productId}/styles`,
+          {},
+          outfitsStylesFetchController,
+        )
+          .then((res2) => {
+            const styleOutfits = res2.data.results;
+            const selectedStyle = styleOutfits.find(
+              (style) => style.style_id === styleId,
+            );
+
+            if (selectedStyle) {
+              outfitsData[res2.data.product_id].photos = selectedStyle.photos;
+              outfitsData[res2.data.product_id].sale_price =
+                selectedStyle.sale_price;
+              outfitsData[res2.data.product_id].original_price =
+                selectedStyle.original_price;
+              setOutfits((prevState) => ({
+                ...prevState,
+                ...outfitsData,
+              }));
+            } else {
+              console.error('Style not found for style_id: ', styleId);
+            }
+          })
+          .catch((err) => {
+            console.error('Error fetching styles data: ', err);
+          });
+      })
+      .catch((err) => {
+        console.error('Error fetching product data: ', err);
+      });
+  };
+
+  const removeItem = (itemId) => {
+    const updatedOutfits = { ...outfits };
+    delete updatedOutfits[itemId];
+
+    setOutfits(updatedOutfits);
+  };
+
   return (
     <>
-      <p>RelatedProducts</p>
-      <p>RelatedProducts</p>
+      {console.log(outfits)}
+      <div className="row-related-title">
+        <h1>
+          <b>Related Products</b>
+        </h1>
+      </div>
+      <div className="row-related-product">
+        <div className="carousel-container">
+          <RelatedProductsList
+            relatedItems={relatedItems}
+            onClickRelatedProduct={onClickRelatedProduct}
+            setProductId={setProductId}
+          />
+        </div>
+      </div>
+      <div className="row-outift-title">
+        <h1>
+          <b>Your Outfit</b>
+        </h1>
+      </div>
+      <div className="row-outfit-product">
+        <div className="outfit-carousel-container">
+          <OutfitList
+            outfits={outfits}
+            onClickAddOutfits={onClickAddOutfits}
+            removeItem={removeItem}
+          />
+        </div>
+      </div>
     </>
   );
 }
-
-// hi
 
 export default RelatedProducts;

--- a/src/components/RelatedProducts/index.jsx
+++ b/src/components/RelatedProducts/index.jsx
@@ -6,12 +6,15 @@ import OutfitList from './OutfitList.jsx';
 import './RelatedProducts.css';
 import './Outfit.css';
 import Modal from '../UI/Modal.jsx';
+import ComparisonTable from './ComparisonTable.jsx';
 /* eslint-enable */
 
 function RelatedProducts({ productId, setProductId, styleId }) {
   //eslint-disable-line
   const [relatedItems, setRelatedItems] = useState(null);
   const [outfits, setOutfits] = useState(null);
+  const [currentId, setcurrentId] = useState(null);
+  const [openComparisonModal, setOpenComparisonModal] = useState(false);
   const relatedFetchController = new AbortController();
   const productIdFetchController = new AbortController();
   const stylesFetchController = new AbortController();
@@ -144,9 +147,13 @@ function RelatedProducts({ productId, setProductId, styleId }) {
     setOutfits(updatedOutfits);
   };
 
+  const setCurrentIdAndUpdateModal = (key) => {
+    setCurrentId(key);
+    setOpenComparisonModal((prev) => !prev);
+  };
+
   return (
     <>
-      {console.log(outfits)}
       <div className="row-related-title">
         <h1>
           <b>Related Products</b>
@@ -158,6 +165,7 @@ function RelatedProducts({ productId, setProductId, styleId }) {
             relatedItems={relatedItems}
             onClickRelatedProduct={onClickRelatedProduct}
             setProductId={setProductId}
+            setCurrentId={setCurrentIdAndUpdateModal}
           />
         </div>
       </div>
@@ -175,6 +183,17 @@ function RelatedProducts({ productId, setProductId, styleId }) {
           />
         </div>
       </div>
+      {/* {openComparisonModal && (
+        <Modal
+          handleClose={() => setOpenComparisonModal(false)}
+          children={
+            <ComparisonTable
+              currentProduct={currentProduct}
+              comparedProduct={relatedItems.relatedItems[relatedItems.currentId]}
+            />
+          }
+        ></Modal>
+      )} */}
     </>
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,22 +7,26 @@ import Overview from './components/Overview/index.jsx';
 import QuestionsAndAnswers from './components/QuestionsAndAnswers/index.jsx';
 import RatingAndReviews from './components/RatingAndReviews/index.jsx';
 import RelatedProducts from './components/RelatedProducts/index.jsx';
+import useServerFetch from './hooks/useServerFetch.js'; //eslint-disable-line
 
 function App() {
   const [productId, setProductId] = React.useState('');
   const [styleId, setStyleId] = React.useState('');
+  const initialProductFetcher = new AbortController();
 
-  axios.get('https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/products', {
-    headers: {
-      Authorization: process.env.AUTH_TOKEN,
-    },
-  })
-    .then((res) => {
-      setProductId(res.data[0].id);
-    })
-    .catch((err) => {
-      console.error(err);
+  React.useEffect(() => {
+    useServerFetch('get', `products`, {}, initialProductFetcher)
+      .then((res) => {
+        setProductId(res.data[0].id);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+
+    return (() => {
+      initialProductFetcher.abort();
     });
+  }, []);
 
 
   return (


### PR DESCRIPTION
This pull request includes the implementation of related products and outfits carousel.

List Behavior of Related Products:
- Requires carousel scrolling
- horizontally
- Finite # of related products
- positioned so first related product
- is flush to left
- onClick arrow function to scroll
- through the list
- At most left, the left arrow should
- be hidden. Likewise to right side

List Behavior of Oufits:

- Carousel list similar to related products
- Items added to list only when user selects them to be added
- First card displays a + icone and read 'add to outfit' (button to add)
- Must make adaptable to individual customer (requires tracking unique session id)
- No duplicates (set)
- No max limit items
- List persist across page navigation (same regardless of each product detail)
- List persist on each session (requires cookie for tracking unique session id)