### PR TITLE
Review fix ratingbar

### DIFF
--- a/src/components/RatingAndReviews/RatingBar.jsx
+++ b/src/components/RatingAndReviews/RatingBar.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const decimalToPercentageString = (decimal) =>
-  Math.round(decimal * 100)
-    .toString()
-    .concat('%');
+const decimalToPercentageString = (decimal) => Math.round(decimal * 100)
+  .toString()
+  .concat('%');
 
 const BarWrapper = styled.div`
   width: 50%;

--- a/src/components/RatingAndReviews/ReviewForm/Characteristics.jsx
+++ b/src/components/RatingAndReviews/ReviewForm/Characteristics.jsx
@@ -63,8 +63,8 @@ function Characteristics({ characteristics, setCharacteristics }) { // eslint-di
   return (
     <Wrapper>
       <legend>Characteristics</legend>
-      {characteristics &&
-        Object.keys(characteristics).map((key) => (
+      {characteristics
+        && Object.keys(characteristics).map((key) => (
           <CharacteristicsRow
             key={key}
             char={characteristics[key].value} // eslint-disable-line

--- a/src/components/RatingAndReviews/ReviewsFilter.jsx
+++ b/src/components/RatingAndReviews/ReviewsFilter.jsx
@@ -15,8 +15,8 @@ const StarFilterLineWrapper = styled.li`
 const getMaxRating = (ratings) => {
   let max = 0;
   for (const value of Object.values(ratings)) { // eslint-disable-line
-    if (value > max) {
-      max = value;
+    if (Number(value) > max) {
+      max = Number(value);
     }
   }
   return max;
@@ -30,22 +30,29 @@ function StarFilterLine({ children, rating }) { // eslint-disable-line
       isActive={starsFilter[rating]}
       onClick={() => toggleStarsFilter(rating)}
     >
-      <span>{rating} Stars</span>
+      <span>
+        {rating}
+        {' '}
+        Stars
+      </span>
       {children}
     </StarFilterLineWrapper>
   );
 }
 
 function ReviewsFilter({ recommended, ratings }) { // eslint-disable-line
-  const recommendRate =
-    Number(recommended.true) / // eslint-disable-line
+  const recommendRate =    Number(recommended.true) / // eslint-disable-line
     (Number(recommended.true) + Number(recommended.false)); // eslint-disable-line
   const maxRating = getMaxRating(ratings);
+
+  console.log({ maxRating });
+  console.log(ratings);
 
   return (
     <Wrapper>
       <div>
-        {Math.round(recommendRate * 100)}% of reviewers recommend this product.
+        {Math.round(recommendRate * 100)}
+        % of reviewers recommend this product.
       </div>
       <StarsFilter>
         <StarFilterLine rating="5">


### PR DESCRIPTION
Made a PR to fix the rating bar bug.
It turned out to be a stupid mistake. I convert the rating from string to number in the numerating when calculating the percentage, but forgot to do so in calculateMax function.  So what I was doing was like:  120 / '480', which sometimes works when JS's auto data converting works but sometimes not.
Now it is fixed. 